### PR TITLE
Move travis-cov config from scripts to config key in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # swig
-[![Build Status](http://img.shields.io/travis/node-swig/swig/master.svg?style=flat)](http://travis-ci.org/node-swig/swig) [![Dependency Status](http://img.shields.io/gemnasium/node-swig/swig-templates.svg?style=flat)](https://gemnasium.com/node-swig/swig) [![NPM version](http://img.shields.io/npm/v/swig-templates.svg?style=flat)](https://www.npmjs.org/package/swig-templates) [![NPM Downloads](http://img.shields.io/npm/dm/swig-templates.svg?style=flat)](https://www.npmjs.org/package/swig-templates)
+[![Build Status](http://img.shields.io/travis/node-swig/swig-templates/master.svg?style=flat)](http://travis-ci.org/node-swig/swig-templates) [![NPM version](http://img.shields.io/npm/v/swig-templates.svg?style=flat)](https://www.npmjs.org/package/swig-templates) [![NPM Downloads](http://img.shields.io/npm/dm/swig-templates.svg?style=flat)](https://www.npmjs.org/package/swig-templates)
 
 [Swig](http://node-swig.github.io/swig-templates/) is an awesome, Django/Jinja-like template engine for node.js.
 

--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "prepublish": "npm prune && make build",
     "test": "make test reporter=spec && make test-browser && make coverage cov-reporter=travis-cov",
     "lint": "make lint",
-    "validate": "npm ls",
-    "travis-cov": {
-      "threshold": 95
-    }
+    "validate": "npm ls"
   },
   "config": {
     "blanket": {
       "pattern": "swig/lib"
+    },
+    "travis-cov": {
+      "threshold": 95
     }
   },
   "bugs": {


### PR DESCRIPTION
Configuration schema for travis-cov changed such that config should be stored under the config key, not the scripts key.
See: https://github.com/alex-seville/travis-cov/issues/2