### PR TITLE
Move travis-cov to config key, correct blanket pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "prepublish": "npm prune && make build",
     "test": "make test reporter=spec && make test-browser && make coverage cov-reporter=travis-cov",
     "lint": "make lint",
-    "validate": "npm ls",
-    "travis-cov": {
-      "threshold": 95
-    }
+    "validate": "npm ls"
   },
   "config": {
     "blanket": {
-      "pattern": "swig/lib"
+      "pattern": "swig-templates/lib"
+    },
+    "travis-cov": {
+      "threshold": 95
     }
   },
   "bugs": {


### PR DESCRIPTION
The coverage make target is using [Blanket](https://www.npmjs.com/package/blanket) for instrumentation. Blanket's configured source pattern in `package.json` apparently no longer matched after the repo was renamed to `swig-templates`. 

These changes cause coverage to successfully run for me locally.