### PR TITLE
:art: robustify publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "swig": "./bin/swig.js"
   },
   "scripts": {
+    "preversion": "git checkout master && git pull && npm ls",
     "prepublish": "npm prune && make build",
+    "publish-patch": "npm run preversion && npm version patch && git push origin master --tags && npm publish",
+    "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",
+    "publish-major": "npm run preversion && npm version major && git push origin master --tags && npm publish",
     "test": "make test reporter=spec && make test-browser && make coverage cov-reporter=travis-cov",
     "lint": "make lint",
     "validate": "npm ls"


### PR DESCRIPTION
# problem statement

- master & the published version can come out of sync w/out CD configured
- release tagging isn't formally a thing

# solution

in &-js, we have a convention that i like.  that is, no one ever manually runs `npm publish`.  rather, if you want to roll a minor, you run `npm run publish-minor`.  this does some biz rules enforcement, tags a GH release, and finally deploys to npm.

# discussion

i created a mismatch between master and our published source as described in #27.  :(  trying to do some corrective actions here!
