### PR TITLE
Fix `this` in swig.compile()

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -602,7 +602,7 @@ exports.Swig = function (opts) {
 
     context = getLocals(options);
     contextLength = utils.keys(context).length;
-    pre = this.precompile(source, options);
+    pre = self.precompile(source, options);
 
     function compiled(locals) {
       var lcls;


### PR DESCRIPTION
The value of `this` might be modified when called in other situations.

All other references to `this` are guarded with `self` in all other functions.